### PR TITLE
added more json test cases, fixed some documentation, changed test to match docs

### DIFF
--- a/app/mixins/game/board_mixin.rb
+++ b/app/mixins/game/board_mixin.rb
@@ -35,7 +35,7 @@ module Game::BoardMixin
   #
   # @param [Array] origin_coord The coordinates to start from
   # @param [Integer] n The distance away from the origin_coord
-  # @return [Array] The coordinates in the diagonal direction, n away from the
+  # @return [Array] The coordinates in the vertical direction, n away from the
   #   origin coords
   def vertical(coords, i)
     [coords[0], coords[1]+i]
@@ -46,7 +46,7 @@ module Game::BoardMixin
   #
   # @param [Array] origin_coord The coordinates to start from
   # @param [Integer] n The distance away from the origin_coord
-  # @return [Array] The coordinates in the diagonal direction, n away from the
+  # @return [Array] The coordinates in the horizontal direction, n away from the
   #   origin coords
   def horizontal(coords, i)
     [coords[0]+i, coords[1]]

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -82,7 +82,7 @@ class Game < ActiveRecord::Base
 
   # Checks if there is a winner and returns the player if it exists
   #
-  # @return [String] 'red', 'blue', 'tie', 'draw', or 'in_progress'
+  # @return [String] 'red', 'blue', 'tie', or 'in_progress'
   def check_for_winner
     # TODO
 

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -171,9 +171,7 @@ describe Game do
 
       games.each do |correct_status, game_data|
         game = Game.create game_data
-        game.check_for_winner
-
-        game.status.should == correct_status
+        game.check_for_winner.should == correct_status
       end
     end
   end

--- a/spec/support/games/game_state.json
+++ b/spec/support/games/game_state.json
@@ -1,11 +1,24 @@
 [
-  ["red", {"board":[["red","blue"],["blue","red"],["red","blue","red"],["blue","red","blue","red"],[],[],[]],"current_player":"blue","status":"in_progress"}],
+    ["tie", {"board":[["blue","red","blue","red","blue","red"],
+                    ["red","blue","red","blue","red","blue"],
+                    ["blue","red","blue","red","blue","red"],
+                    ["blue","red","blue","red","blue","red"],
+                    ["red","blue","red","blue","red","blue"],
+                    ["blue","red","blue","red","blue","red"],
+                    ["blue","red","blue","red","blue","red"]],"current_player":"red","status":"in_progress"}],
+    ["in_progress", {"board":[["blue","red","red","blue"],
+        ["red","blue","blue"],
+        ["blue","red","red","red"],["red","blue"],["blue"],["blue","red"],[]],"current_player":"blue","status":"in_progress"}],
+
+  ["red",{"board":[["red","blue"],["blue","red"],["red","blue","red"],["blue","red","blue","red"],[],[],[]],"current_player":"blue","status":"in_progress"}],
   ["in_progress",{"board":[[],[],[],[],[],[],[]],"current_player":null,"status":"in_progress"}],
   ["red",{"board":[["red","blue"],["red","blue"],["red","blue"],["red"],[],[],[]],"current_player":"blue","status":"in_progress"}],
   ["red",{"board":[["red","red","red","red"],["blue","blue"],[],["blue"],[],[],[]],"current_player":"blue","status":"in_progress"}],
+  ["red",{"board":[["blue","blue"],["blue","red","red","red"],["red","blue","red"],["blue","red","blue","red"],["red"],[],[]],"current_player":"blue","status":"in_progress"}],
 
-  ["blue", {"board":[["blue","red"],["red","blue"],["blue","red","blue"],["red","blue","red","blue"],[],[],[]],"current_player":"red","status":"in_progress"}],
+  ["blue",{"board":[["blue","red"],["red","blue"],["blue","red","blue"],["red","blue","red","blue"],[],[],[]],"current_player":"red","status":"in_progress"}],
   ["in_progress",{"board":[[],[],[],[],[],[],[]],"current_player":null,"status":"in_progress"}],
   ["blue",{"board":[["blue","red"],["blue","red"],["blue","red"],["blue"],[],[],[]],"current_player":"red","status":"in_progress"}],
-  ["blue",{"board":[["blue","blue","blue","blue"],["red","red"],[],["red"],[],[],[]],"current_player":"red","status":"in_progress"}]
+  ["blue",{"board":[["blue","blue","blue","blue"],["red","red"],[],["red"],[],[],[]],"current_player":"red","status":"in_progress"}],
+  ["blue",{"board":[["red","red"],["red","blue","blue","blue"],["blue","red","blue"],["red","blue","red","blue"],["blue"],[],[]],"current_player":"red","status":"in_progress"}]
 ]


### PR DESCRIPTION
New test cases for check_for_winner: in_progress, tie, diagonal left (red), diagonal left (blue).  (I didn't include the mixin method for doing a diagonal left, let me know if you want me to add that to the pull request)

The doc changes are pretty straightforward.

The test change is sort of an opinion thing though.  The docs for check_for_winner and make_move both imply that check_for_winner does _not_ set any fields on the game, and that make_move is responsible for saving the return of check_for_winner somewhere.  But the test for check_for_winner implies that the method should change the value of game.status and not necessarily return anything.  I think the docs version creates a cleaner interface so I changed the test to match.  If you disagree I can change it back.
